### PR TITLE
Create document formatting application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Auto Doc
+
+Приложение автоматически форматирует текстовые документы по описанным в методичке правилам. Решение включает:
+
+- библиотеку для загрузки методички и применения форматирующих правил;
+- консольный интерфейс на базе `argparse` для форматирования локальных файлов;
+- лёгкий HTTP-сервер на стандартной библиотеке, принимающий файлы и возвращающий отформатированный текст.
+
+## Быстрый старт
+
+Проект не требует внешних зависимостей, поэтому достаточно активировать виртуальное окружение (при необходимости) и добавить каталог проекта в `PYTHONPATH`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+export PYTHONPATH=.
+```
+
+### Форматирование файла из CLI
+
+```bash
+python -m auto_doc format input.txt --output formatted.txt
+```
+
+По умолчанию используется методичка `auto_doc/resources/default_methodology.toml`. Для применения пользовательских правил передайте путь к TOML-файлу:
+
+```bash
+python -m auto_doc format input.txt --methodology custom_rules.toml
+```
+
+### Запуск HTTP-сервера
+
+```bash
+python -m auto_doc serve --host 0.0.0.0 --port 8080
+```
+
+Загрузите документ через POST `/format` с файлом `file` (тип `multipart/form-data`). Ответом будет отформатированный текст документа.
+
+## Тестирование
+
+```bash
+PYTHONPATH=. pytest
+```
+
+## Структура методички
+
+Методичка описывается в TOML-формате. Основные секции:
+
+- `title` — правила для заголовка документа (`transform` — верхний регистр, `prefix`/`suffix` — дополнительные строки).
+- `sections` — нумерация и формат заголовков разделов (`numbering`, `start_level`, `format`, `case`).
+- `paragraphs` — отступы и количество пустых строк между абзацами (`indent`, `spacing`).
+- `bullets` — символ маркированных списков (`marker`, `indent`).
+- `text` — общие правила очистки (`collapse_whitespace`, `strip_trailing_spaces`).
+- `replacements` — список регулярных замен (`pattern`, `replacement`, `flags`).
+
+Пример настроек см. в `auto_doc/resources/default_methodology.toml`.

--- a/auto_doc/__init__.py
+++ b/auto_doc/__init__.py
@@ -1,0 +1,8 @@
+"""Auto Doc package."""
+
+from .formatter import DocumentFormatter
+from .methodology import Methodology, load_methodology
+
+__all__ = ["DocumentFormatter", "Methodology", "load_methodology"]
+
+__version__ = "0.1.0"

--- a/auto_doc/__main__.py
+++ b/auto_doc/__main__.py
@@ -1,0 +1,6 @@
+"""Точка входа для запуска из `python -m auto_doc`."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/auto_doc/cli.py
+++ b/auto_doc/cli.py
@@ -1,0 +1,76 @@
+"""CLI для форматирования документов."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional, Sequence
+
+from .formatter import DocumentFormatter
+from .methodology import load_methodology
+from .server import serve as run_server
+
+
+def _handle_format(args: argparse.Namespace) -> None:
+    input_path = Path(args.input_path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Файл не найден: {input_path}")
+
+    methodology_path: Optional[Path] = Path(args.methodology) if args.methodology else None
+    rules = load_methodology(methodology_path)
+    formatter = DocumentFormatter(rules)
+    source_text = input_path.read_text(encoding="utf-8")
+    formatted = formatter.format_text(source_text)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(formatted, encoding="utf-8")
+        print(f"Документ сохранён в {output_path}")
+    else:
+        sys.stdout.write(formatted)
+
+
+def _handle_serve(args: argparse.Namespace) -> None:
+    run_server(host=args.host, port=args.port, methodology=args.methodology)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Инструменты автоматического форматирования документов")
+    subparsers = parser.add_subparsers(dest="command")
+
+    format_parser = subparsers.add_parser("format", help="Отформатировать локальный документ")
+    format_parser.add_argument("input_path", help="Путь к исходному файлу")
+    format_parser.add_argument("-o", "--output", help="Путь для сохранения результата")
+    format_parser.add_argument("-m", "--methodology", help="Путь к TOML/JSON методичке")
+    format_parser.set_defaults(func=_handle_format)
+
+    serve_parser = subparsers.add_parser("serve", help="Запустить HTTP-сервер форматирования")
+    serve_parser.add_argument("--host", default="0.0.0.0", help="Адрес сервера")
+    serve_parser.add_argument("--port", type=int, default=8000, help="Порт сервера")
+    serve_parser.add_argument("-m", "--methodology", help="Путь к методичке, применяемой по умолчанию")
+    serve_parser.set_defaults(func=_handle_serve)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return 0
+    try:
+        args.func(args)
+        return 0
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"Ошибка: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+
+__all__ = ["main", "build_parser"]

--- a/auto_doc/formatter.py
+++ b/auto_doc/formatter.py
@@ -1,0 +1,224 @@
+"""Основная логика форматирования документов."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Sequence
+
+from .methodology import Methodology
+
+
+class DocumentFormatter:
+    """Применяет правила методички к тексту документа."""
+
+    def __init__(self, methodology: Methodology) -> None:
+        self.methodology = methodology
+        self._compiled_replacements: Sequence[tuple[re.Pattern[str], str]] = [
+            (rule.compile(), rule.replacement) for rule in methodology.replacements
+        ]
+
+    def format_text(self, text: str) -> str:
+        """Отформатировать строку с текстом документа."""
+
+        if not text:
+            return ""
+
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+        lines = [line.rstrip() for line in normalized.split("\n")]
+
+        lines = self._apply_title(lines)
+        lines = self._format_headings(lines)
+        lines = self._format_bullets(lines)
+        lines = self._indent_paragraphs(lines)
+        lines = self._apply_spacing(lines)
+
+        result = "\n".join(lines)
+        result = self._cleanup_text(result)
+        cleaned = result.strip()
+        return cleaned + "\n" if cleaned else ""
+
+    def format_file(self, path: str, output_path: str | None = None) -> str:
+        """Загрузить файл, отформатировать и сохранить результат."""
+
+        with open(path, "r", encoding="utf-8") as fh:
+            source = fh.read()
+        formatted = self.format_text(source)
+        target_path = output_path or path
+        with open(target_path, "w", encoding="utf-8") as fh:
+            fh.write(formatted)
+        return formatted
+
+    # --- внутренние этапы форматирования ---
+
+    def _apply_title(self, lines: List[str]) -> List[str]:
+        result = list(lines)
+        for idx, line in enumerate(result):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            formatted = self._format_title_line(stripped)
+            result[idx] = formatted
+            if idx + 1 < len(result):
+                if result[idx + 1].strip():
+                    result.insert(idx + 1, "")
+            else:
+                result.append("")
+            break
+        return result
+
+    def _format_title_line(self, line: str) -> str:
+        prefix = self.methodology.title_prefix or ""
+        suffix = self.methodology.title_suffix or ""
+        if line.startswith("#"):
+            match = re.match(r"^(#+)\s*(.+)$", line)
+            if match:
+                hashes, text = match.groups()
+                text = self._transform_case(text.strip(), self.methodology.title_transform)
+                return f"{hashes} {prefix}{text}{suffix}".rstrip()
+        text = self._transform_case(line.strip(), self.methodology.title_transform)
+        return f"{prefix}{text}{suffix}".strip()
+
+    def _format_headings(self, lines: List[str]) -> List[str]:
+        result: List[str] = []
+        counters: List[int] = []
+        heading_pattern = re.compile(r"^(\s*)(#+)\s*(.+)$")
+
+        for line in lines:
+            match = heading_pattern.match(line)
+            if match:
+                indent, hashes, title = match.groups()
+                if result and result[-1].strip():
+                    result.append("")
+                clean_title = self._strip_existing_numbering(title.strip())
+                clean_title = self._transform_case(clean_title, self.methodology.section_case)
+                number = ""
+                if self.methodology.section_numbering:
+                    number = self._next_section_number(counters, len(hashes))
+                else:
+                    counters.clear()
+                if number:
+                    body = self.methodology.section_format.format(number=number, title=clean_title)
+                else:
+                    body = clean_title
+                formatted = f"{indent}{hashes} {body}".rstrip()
+                result.append(formatted)
+                result.append("")
+            else:
+                result.append(line)
+        return result
+
+    def _format_bullets(self, lines: List[str]) -> List[str]:
+        bullet_pattern = re.compile(r"^(\s*)[\-*+•]\s+(.+)$")
+        result: List[str] = []
+        for line in lines:
+            match = bullet_pattern.match(line)
+            if match:
+                indent, body = match.groups()
+                indent_to_use = indent if indent else " " * self.methodology.bullet_indent
+                result.append(f"{indent_to_use}{self.methodology.bullet_marker} {body.strip()}")
+            else:
+                result.append(line)
+        return result
+
+    def _indent_paragraphs(self, lines: List[str]) -> List[str]:
+        indent = " " * self.methodology.paragraph_indent
+        result: List[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                result.append("")
+                continue
+            lstripped = line.lstrip()
+            if self._is_structural_line(lstripped):
+                result.append(line)
+                continue
+            if line.startswith(" "):
+                result.append(line)
+                continue
+            result.append(f"{indent}{stripped}")
+        return result
+
+    def _apply_spacing(self, lines: List[str]) -> List[str]:
+        result: List[str] = []
+        blank_count = 0
+        max_blank = self.methodology.paragraph_spacing
+        for line in lines:
+            if line.strip():
+                if blank_count:
+                    allowed = max_blank if max_blank > 0 else 0
+                    result.extend([""] * min(blank_count, allowed))
+                    blank_count = 0
+                result.append(line.rstrip())
+            else:
+                blank_count += 1
+        while result and not result[-1].strip():
+            result.pop()
+        return result
+
+    def _cleanup_text(self, text: str) -> str:
+        cleaned = text
+        if self.methodology.text_strip_trailing_spaces:
+            cleaned = "\n".join(line.rstrip() for line in cleaned.splitlines())
+        if self.methodology.text_collapse_whitespace:
+            collapsed_lines = []
+            for line in cleaned.splitlines():
+                if not line.strip():
+                    collapsed_lines.append("")
+                    continue
+                indent = len(line) - len(line.lstrip(" "))
+                body = re.sub(r"[ \t]{2,}", " ", line.lstrip(" "))
+                collapsed_lines.append(" " * indent + body)
+            cleaned = "\n".join(collapsed_lines)
+        cleaned = re.sub(r"\s+,", ",", cleaned)
+        cleaned = re.sub(r",\s+", ", ", cleaned)
+        cleaned = re.sub(r"\s+\.", ".", cleaned)
+        for pattern, replacement in self._compiled_replacements:
+            cleaned = pattern.sub(replacement, cleaned)
+        return cleaned
+
+    def _transform_case(self, text: str, mode: str) -> str:
+        mode_lower = (mode or "").lower()
+        if mode_lower == "upper":
+            return text.upper()
+        if mode_lower == "lower":
+            return text.lower()
+        if mode_lower == "title":
+            return text.title()
+        if mode_lower == "capitalize":
+            return text.capitalize()
+        if mode_lower == "sentence":
+            return text[:1].upper() + text[1:]
+        return text
+
+    def _strip_existing_numbering(self, text: str) -> str:
+        pattern = re.compile(r"^\d+(?:\.\d+)*(?:[\.)-])?\s+")
+        return pattern.sub("", text, count=1).strip()
+
+    def _next_section_number(self, counters: List[int], level: int) -> str:
+        relative = level - self.methodology.section_start_level
+        if relative < 0:
+            counters.clear()
+            return ""
+        while len(counters) <= relative:
+            counters.append(0)
+        counters[relative] += 1
+        for idx in range(relative + 1, len(counters)):
+            counters[idx] = 0
+        numbers = [str(num) for num in counters[: relative + 1] if num]
+        return ".".join(numbers)
+
+    def _is_structural_line(self, line: str) -> bool:
+        if not line:
+            return True
+        if line.startswith("#"):
+            return True
+        if line.startswith((">", "`")):
+            return True
+        if re.match(r"^[-*+]\s", line):
+            return True
+        if re.match(r"^\d+[\.)]\s", line):
+            return True
+        return False
+
+
+__all__ = ["DocumentFormatter"]

--- a/auto_doc/methodology.py
+++ b/auto_doc/methodology.py
@@ -1,0 +1,124 @@
+"""Загрузка и описание методических правил."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import os
+from pathlib import Path
+import re
+from typing import Any, List, Optional
+
+import tomllib
+
+_FLAG_MAP: dict[str, int] = {
+    "IGNORECASE": re.IGNORECASE,
+    "MULTILINE": re.MULTILINE,
+    "DOTALL": re.DOTALL,
+}
+
+
+@dataclass
+class ReplacementRule:
+    """Регулярное выражение и подстановка."""
+
+    pattern: str
+    replacement: str
+    flags: List[str] = field(default_factory=list)
+
+    def compile(self) -> re.Pattern[str]:
+        flag_value = 0
+        for name in self.flags:
+            flag_value |= _FLAG_MAP.get(name.upper(), 0)
+        pattern_text = self.pattern.encode("utf-8").decode("unicode_escape")
+        return re.compile(pattern_text, flags=flag_value)
+
+
+@dataclass
+class Methodology:
+    """Набор правил форматирования."""
+
+    title_transform: str = "upper"
+    title_prefix: str = ""
+    title_suffix: str = ""
+    section_numbering: bool = True
+    section_start_level: int = 2
+    section_format: str = "{number}. {title}"
+    section_case: str = "title"
+    paragraph_indent: int = 4
+    paragraph_spacing: int = 1
+    bullet_marker: str = "-"
+    bullet_indent: int = 2
+    text_collapse_whitespace: bool = True
+    text_strip_trailing_spaces: bool = True
+    replacements: List[ReplacementRule] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Methodology":
+        title = data.get("title", {}) or {}
+        sections = data.get("sections", {}) or {}
+        paragraphs = data.get("paragraphs", {}) or {}
+        bullets = data.get("bullets", {}) or {}
+        text = data.get("text", {}) or {}
+        replacements = [
+            ReplacementRule(
+                pattern=item.get("pattern", ""),
+                replacement=item.get("replacement", ""),
+                flags=list(item.get("flags", []) or []),
+            )
+            for item in data.get("replacements", []) or []
+        ]
+
+        return cls(
+            title_transform=str(title.get("transform", "upper")),
+            title_prefix=str(title.get("prefix", "")),
+            title_suffix=str(title.get("suffix", "")),
+            section_numbering=bool(sections.get("numbering", True)),
+            section_start_level=int(sections.get("start_level", 2)),
+            section_format=str(sections.get("format", "{number}. {title}")),
+            section_case=str(sections.get("case", "title")),
+            paragraph_indent=int(paragraphs.get("indent", 4)),
+            paragraph_spacing=max(0, int(paragraphs.get("spacing", 1))),
+            bullet_marker=str(bullets.get("marker", "-")),
+            bullet_indent=int(bullets.get("indent", 2)),
+            text_collapse_whitespace=bool(text.get("collapse_whitespace", True)),
+            text_strip_trailing_spaces=bool(text.get("strip_trailing_spaces", True)),
+            replacements=replacements,
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "Methodology":
+        suffix = path.suffix.lower()
+        if suffix in {".toml", ".tml"}:
+            with path.open("rb") as fh:
+                content = tomllib.load(fh) or {}
+        elif suffix == ".json":
+            with path.open("r", encoding="utf-8") as fh:
+                content = json.load(fh) or {}
+        else:
+            raise ValueError("Поддерживаются файлы TOML или JSON")
+        if not isinstance(content, dict):
+            raise ValueError("Методичка должна быть словарём")
+        return cls.from_dict(content)
+
+
+def load_methodology(path: Optional[Path | str] = None) -> Methodology:
+    """Загрузить методичку из файла или переменной окружения."""
+
+    resolved: Optional[Path] = None
+    env_path = os.getenv("AUTO_DOC_METHOD_PATH")
+    if path is not None:
+        resolved = Path(path)
+    elif env_path:
+        resolved = Path(env_path)
+
+    if resolved is None:
+        resolved = Path(__file__).resolve().parent / "resources" / "default_methodology.toml"
+
+    if not resolved.exists():
+        raise FileNotFoundError(f"Файл методички не найден: {resolved}")
+
+    return Methodology.from_path(resolved)
+
+
+__all__ = ["Methodology", "ReplacementRule", "load_methodology"]

--- a/auto_doc/resources/default_methodology.toml
+++ b/auto_doc/resources/default_methodology.toml
@@ -1,0 +1,27 @@
+[title]
+transform = "upper"
+prefix = ""
+suffix = ""
+
+[sections]
+numbering = true
+start_level = 2
+format = "{number}. {title}"
+case = "title"
+
+[paragraphs]
+indent = 4
+spacing = 1
+
+[bullets]
+marker = "-"
+indent = 2
+
+[text]
+collapse_whitespace = true
+strip_trailing_spaces = true
+
+[[replacements]]
+pattern = '\\s*,\\s*'
+replacement = ', '
+flags = ['MULTILINE']

--- a/auto_doc/server.py
+++ b/auto_doc/server.py
@@ -1,0 +1,136 @@
+"""HTTP-сервер для форматирования документов."""
+
+from __future__ import annotations
+
+import cgi
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import parse_qs, urlparse
+
+from .formatter import DocumentFormatter
+from .methodology import Methodology, load_methodology
+
+
+class FormatterRequestHandler(BaseHTTPRequestHandler):
+    """Обработчик HTTP-запросов."""
+
+    server_version = "AutoDoc/0.1"
+    protocol_version = "HTTP/1.1"
+    default_methodology: Optional[Path] = None
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path == "/health":
+            self._send_json({"status": "ok"})
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND, "Маршрут не найден")
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        if parsed.path != "/format":
+            self.send_error(HTTPStatus.NOT_FOUND, "Маршрут не найден")
+            return
+
+        content_type = self.headers.get("Content-Type")
+        if not content_type:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Отсутствует заголовок Content-Type")
+            return
+        ctype, _ = cgi.parse_header(content_type)
+        if ctype != "multipart/form-data":
+            self.send_error(HTTPStatus.BAD_REQUEST, "Используйте multipart/form-data")
+            return
+
+        environ = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": content_type,
+            "CONTENT_LENGTH": self.headers.get("Content-Length", "0"),
+        }
+        form = cgi.FieldStorage(fp=self.rfile, headers=self.headers, environ=environ, keep_blank_values=True)
+        if "file" not in form:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Файл не найден в запросе")
+            return
+
+        file_item = form["file"]
+        raw_data = file_item.file.read() if getattr(file_item, "file", None) else file_item.value
+        if isinstance(raw_data, str):
+            raw_bytes = raw_data.encode("utf-8")
+        else:
+            raw_bytes = raw_data
+        try:
+            text = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Файл должен быть в кодировке UTF-8")
+            return
+
+        methodology_override = None
+        if "methodology" in form:
+            methodology_override = form.getvalue("methodology") or None
+        elif parsed.query:
+            methodology_override = parse_qs(parsed.query).get("methodology", [None])[0]
+
+        try:
+            formatter = self._get_formatter(methodology_override)
+        except FileNotFoundError as exc:
+            self.send_error(HTTPStatus.NOT_FOUND, str(exc))
+            return
+        except ValueError as exc:
+            self.send_error(HTTPStatus.BAD_REQUEST, str(exc))
+            return
+
+        formatted = formatter.format_text(text)
+        if not formatted:
+            self.send_error(HTTPStatus.BAD_REQUEST, "Документ пуст или не содержит текста")
+            return
+        self._send_text(formatted)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        """Подавить стандартный вывод логов тестов."""
+
+        return
+
+    def _get_formatter(self, override: Optional[str]) -> DocumentFormatter:
+        path = Path(override) if override else self.default_methodology
+        rules: Methodology = load_methodology(path)
+        return DocumentFormatter(rules)
+
+    def _send_json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_text(self, payload: str, status: HTTPStatus = HTTPStatus.OK) -> None:
+        body = payload.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def create_server(host: str = "0.0.0.0", port: int = 8000, methodology: Optional[str] = None) -> ThreadingHTTPServer:
+    """Создать HTTP-сервер без запуска."""
+
+    handler = FormatterRequestHandler
+    handler.default_methodology = Path(methodology) if methodology else None
+    return ThreadingHTTPServer((host, port), handler)
+
+
+def serve(host: str = "0.0.0.0", port: int = 8000, methodology: Optional[str] = None) -> None:
+    """Запустить HTTP-сервер и обрабатывать запросы."""
+
+    server = create_server(host, port, methodology)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - ручная остановка
+        pass
+    finally:
+        server.server_close()
+
+
+__all__ = ["create_server", "serve", "FormatterRequestHandler"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "auto-doc"
+version = "0.1.0"
+description = "Приложение для загрузки и форматирования документов по методическим правилам"
+readme = "README.md"
+authors = [{name = "Auto Generated", email = "auto@example.com"}]
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+auto-doc = "auto_doc.cli:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from auto_doc.formatter import DocumentFormatter
+from auto_doc.methodology import load_methodology
+
+
+def make_formatter() -> DocumentFormatter:
+    rules = load_methodology(Path(__file__).resolve().parents[1] / "auto_doc" / "resources" / "default_methodology.toml")
+    return DocumentFormatter(rules)
+
+
+def test_title_and_paragraph_formatting():
+    formatter = make_formatter()
+    text = "Документ\nПервый абзац без форматирования."
+    formatted = formatter.format_text(text)
+    lines = formatted.splitlines()
+    assert lines[0] == "ДОКУМЕНТ"
+    assert lines[1] == ""
+    assert lines[2].startswith("    ")
+
+
+def test_section_numbering():
+    formatter = make_formatter()
+    text = "# Документ\n## Раздел\nСодержимое\n### Подраздел\nТекст\n## Второй раздел\n"
+    formatted = formatter.format_text(text)
+    lines = formatted.splitlines()
+    assert "## 1. Раздел" in lines
+    assert "### 1.1. Подраздел" in lines
+    assert "## 2. Второй Раздел" in lines
+
+
+def test_bullet_and_spacing():
+    formatter = make_formatter()
+    text = "Документ\n- пункт\n* второй пункт\nФинальный абзац\n"
+    formatted = formatter.format_text(text)
+    lines = formatted.splitlines()
+    assert lines[2].startswith("  - ")
+    assert lines[3].startswith("  - ")
+    assert lines[-1].startswith("    ")
+
+
+def test_replacements():
+    formatter = make_formatter()
+    text = "Документ\nФраза , с пробелами .\n"
+    formatted = formatter.format_text(text)
+    assert ", с" in formatted
+    assert " ." not in formatted
+    assert " ," not in formatted

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,83 @@
+import json
+import threading
+import time
+from http.client import HTTPConnection
+from typing import Dict, Tuple
+from uuid import uuid4
+
+from auto_doc.server import create_server
+
+
+def _build_multipart(
+    files: Dict[str, Tuple[str, str, str]],
+    fields: Dict[str, str] | None = None,
+) -> Tuple[str, bytes]:
+    boundary = f"----AutoDocBoundary{uuid4().hex}"
+    lines: list[str] = []
+    for name, value in (fields or {}).items():
+        lines.append(f"--{boundary}")
+        lines.append(f'Content-Disposition: form-data; name="{name}"')
+        lines.append("")
+        lines.append(value)
+    for name, (filename, content, content_type) in files.items():
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        lines.append(f"--{boundary}")
+        lines.append(f'Content-Disposition: form-data; name="{name}"; filename="{filename}"')
+        lines.append(f"Content-Type: {content_type}")
+        lines.append("")
+        lines.append(content)
+    lines.append(f"--{boundary}--")
+    lines.append("")
+    body = "\r\n".join(lines).encode("utf-8")
+    return boundary, body
+
+
+def _start_server():
+    server = create_server("127.0.0.1", 0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    return server, thread
+
+
+def _stop_server(server, thread):
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=0.2)
+
+
+def test_healthcheck():
+    server, thread = _start_server()
+    host, port = server.server_address
+    conn = HTTPConnection(host, port)
+    try:
+        conn.request("GET", "/health")
+        response = conn.getresponse()
+        data = json.loads(response.read().decode("utf-8"))
+        assert response.status == 200
+        assert data["status"] == "ok"
+    finally:
+        conn.close()
+        _stop_server(server, thread)
+
+
+def test_format_endpoint():
+    server, thread = _start_server()
+    host, port = server.server_address
+    boundary, body = _build_multipart({"file": ("doc.txt", "Документ\nРаздел\n", "text/plain")})
+    headers = {
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+        "Content-Length": str(len(body)),
+    }
+    conn = HTTPConnection(host, port)
+    try:
+        conn.request("POST", "/format", body=body, headers=headers)
+        response = conn.getresponse()
+        text = response.read().decode("utf-8")
+        assert response.status == 200
+        assert "ДОКУМЕНТ" in text
+        assert "Раздел" in text
+    finally:
+        conn.close()
+        _stop_server(server, thread)


### PR DESCRIPTION
## Summary
- implement a methodology-driven `DocumentFormatter` with numbering, paragraph formatting and cleanup helpers
- add an argparse-based CLI and standard-library HTTP server for uploading and formatting documents
- supply a TOML methodology template and pytest coverage for formatter and server behaviour

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ccee1e224483288fa0006ef026fe74